### PR TITLE
name: add module

### DIFF
--- a/inspire_utils/name.py
+++ b/inspire_utils/name.py
@@ -1,0 +1,248 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+from itertools import product
+
+import six
+from nameparser import HumanName
+from nameparser.config import Constants
+from unidecode import unidecode
+
+
+_LASTNAME_NON_LASTNAME_SEPARATORS = [u' ', u', ']
+
+
+def _prepare_nameparser_constants():
+    """Prepare nameparser Constants.
+
+    Remove nameparser's titles and use our own and add as suffixes the roman numerals.
+    Configuration is the same for all names (i.e. instances).
+    """
+    constants = Constants()
+    roman_numeral_suffixes = [u'v', u'vi', u'vii', u'viii', u'ix', u'x',
+                              u'xii', u'xiii', u'xiv', u'xv']
+    titles = [u'Dr', u'Prof', u'Professor', u'Sir', u'Editor', u'Ed', u'Mr',
+              u'Mrs', u'Ms', u'Chair', u'Co-Chair', u'Chairs', u'co-Chairs']
+    constants.titles.remove(*constants.titles).add(*titles)
+    constants.suffix_not_acronyms.add(*roman_numeral_suffixes)
+    return constants
+
+
+class ParsedName(object):
+    """Class for representing a name.
+
+    After construction, the instance exposes the fields exposed by `HumanName` instance, i.e.
+    `title`, `first`, `middle`, `last`, `suffix`.
+    """
+    constants = _prepare_nameparser_constants()
+    """The default constants configuration for `HumanName` to use for parsing all names."""
+
+    def __init__(self, name, constants=None):
+        """Create a ParsedName instance.
+
+        Args:
+            name (str): The name to be parsed (must be non empty nor None).
+            constants (:class:`nameparser.config.Constants`): Configuration for `HumanName` instantiation.
+                (Can be None, if provided it overwrites the default one generated in
+                :method:`prepare_nameparser_constants`.)
+        """
+        if not constants:
+            constants = ParsedName.constants
+        self.parsed_name = HumanName(name, constants=constants)
+
+    def __repr__(self):
+        return repr(self.parsed_name)
+
+    def __str__(self):
+        return str(self.parsed_name)
+
+    @classmethod
+    def loads(cls, name):
+        """Load a parsed name from a string.
+
+        Raises:
+            TypeError: when name isn't a type of `six.string_types`.
+            ValueError: when name is empty or None.
+        """
+        if not isinstance(name, six.string_types):
+            raise TypeError('arguments to {classname} must be of type {string_types}'.format(
+                classname=cls.__name__, string_types=repr(six.string_types)
+            ))
+        if not name or name.isspace():
+            raise ValueError('name must not be empty')
+
+        return cls(name)
+
+    def dumps(self):
+        """Dump the name to string, after normalizing it."""
+        def _is_initial(author_name):
+            return len(author_name) == 1 or u'.' in author_name
+
+        def _ensure_dotted_initials(author_name):
+            if _is_initial(author_name) \
+                    and u'.' not in author_name:
+                seq = (author_name, u'.')
+                author_name = u''.join(seq)
+            return author_name
+
+        def _ensure_dotted_suffixes(author_suffix):
+            if u'.' not in author_suffix:
+                seq = (author_suffix, u'.')
+                author_suffix = u''.join(seq)
+            return author_suffix
+
+        def _is_roman_numeral(suffix):
+            """Controls that the user's input only contains valid roman numerals"""
+            valid_roman_numerals = [u'M', u'D', u'C', u'L', u'X',
+                                    u'V', u'I', u'(', u')']
+            return all(letters in valid_roman_numerals
+                       for letters in suffix.upper())
+
+        # Create first and middle
+        first_name = _ensure_dotted_initials(self.parsed_name.first)
+        middle_name = _ensure_dotted_initials(self.parsed_name.middle)
+
+        if _is_initial(first_name) and _is_initial(middle_name):
+            normalized_names = u'{first_name}{middle_name}'
+        else:
+            normalized_names = u'{first_name} {middle_name}'
+
+        normalized_names = normalized_names.format(
+            first_name=first_name,
+            middle_name=middle_name,
+        )
+
+        if _is_roman_numeral(self.parsed_name.suffix):
+            suffix = self.parsed_name.suffix.upper()
+        else:
+            suffix = _ensure_dotted_suffixes(self.parsed_name.suffix)
+
+        final_name = u', '.join(
+            part for part in (self.parsed_name.last, normalized_names.strip(), suffix)
+            if part)
+
+        # Replace unicode curly apostrophe to normal apostrophe.
+        final_name = final_name.replace(u'’', '\'')
+
+        return final_name
+
+
+def normalize_name(name):
+    """Normalize name.
+
+    Args:
+        name (six.text_type): The name to be normalized.
+
+    Returns:
+        str: The normalized name.
+    """
+    if not name or name.isspace():
+        return None
+
+    return ParsedName.loads(name).dumps()
+
+
+def _generate_non_lastnames_variations(non_lastnames):
+    """Generate variations for all non-lastnames.
+
+    E.g. For 'John Richard', this method generates: [
+        'John', 'J', 'Richard', 'R', 'John Richard', 'John R', 'J Richard', 'J R',
+    ]
+    """
+    if not non_lastnames:
+        return []
+
+    # Generate name transformations in place for all non lastnames. Transformations include:
+    # 1. Drop non last name, 2. use initial, 3. use full non lastname
+    for idx, non_lastname in enumerate(non_lastnames):
+        non_lastnames[idx] = (u'', non_lastname[0], non_lastname)
+
+    # Generate the cartesian product of the transformed non lastnames and flatten them.
+    return [(u' '.join(variation)).strip() for variation in product(*non_lastnames)]
+
+
+def _generate_lastnames_variations(lastnames):
+    """Generate variations for lastnames.
+
+    Note:
+        This method follows the assumption that the first last
+        E.g. For 'Caro Estevez', this method generates: ['Caro', 'Caro Estevez'].
+        In the case the lastnames are dashed, it splits them in two.
+    """
+    if not lastnames:
+        return []
+
+    split_lastnames = [split_lastname for lastname in lastnames for split_lastname in lastname.split('-')]
+
+    lastnames_variations = [split_lastnames[0]]  # Always have the first lastname as a variation.
+    if len(split_lastnames) > 1:
+        # Generate lastnames concatenation if there are more than one lastname after split.
+        lastnames_variations.append(u' '.join([lastname for lastname in split_lastnames]))
+
+    return lastnames_variations
+
+
+def generate_name_variations(name):
+    """Generate name variations for a given name.
+
+    Args:
+        name (six.text_type): The name whose variations are to be generated.
+
+    Returns:
+        list: All the name variations for the given name.
+
+    Notes:
+        Uses `unidecode` for doing unicode characters transliteration to ASCII ones. This was chosen so that we can map
+        both full names of authors in HEP records and user's input to the same space and thus make exact queries work.
+    """
+    def _update_name_variations_with_product(set_a, set_b, non_lastnames_idx_in_product_result):
+        name_variations.update([
+            unidecode(
+                (names_variation[0] + separator + names_variation[1]).strip(''.join(_LASTNAME_NON_LASTNAME_SEPARATORS))
+            )
+            for names_variation
+            in product(set_a, set_b)
+            if names_variation[non_lastnames_idx_in_product_result]  # Don't generate only lastnames as variations.
+            for separator
+            in _LASTNAME_NON_LASTNAME_SEPARATORS
+        ])
+
+    parsed_name = ParsedName.loads(name).parsed_name
+
+    # Handle rare-case of single-name
+    if len(parsed_name) == 1:
+        return [name]
+
+    name_variations = set()
+    non_lastnames_variations = \
+        _generate_non_lastnames_variations(non_lastnames=parsed_name.first_list + parsed_name.middle_list)
+    lastnames_variations = _generate_lastnames_variations(parsed_name.last_list)
+
+    # Create variations where lastnames comes first and is separated from non lastnames either by space or comma.
+    _update_name_variations_with_product(lastnames_variations, non_lastnames_variations, 1)
+
+    # Second part of transformations - having the lastnames in the end.
+    _update_name_variations_with_product(non_lastnames_variations, lastnames_variations, 0)
+
+    return list(name_variations)

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,10 @@ setup_requires = [
 install_requires = [
     'babel~=2.0,>=2.5.1',
     'lxml~=4.0,>=4.0.0',
+    'nameparser~=0.0,>=0.5.3',
     'python-dateutil~=2.0,>=2.6.1',
     'six~=1.0,>=1.10.0',
+    'unidecode~=0.0,>=0.4.21',
 ]
 
 docs_require = []

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from inspire_utils.name import normalize_name, generate_name_variations
+
+
+def test_normalize_name_full():
+    expected = 'Smith, John Peter'
+
+    assert expected == normalize_name('Smith, John Peter')
+
+
+def test_normalize_name_handles_names_with_first_initial():
+    expected = 'Smith, J. Peter'
+
+    assert expected == normalize_name('Smith, J Peter')
+    assert expected == normalize_name('Smith, J. Peter')
+    assert expected == normalize_name('Smith, J. Peter ')
+
+
+def test_normalize_name_handles_names_with_middle_initial():
+    expected = 'Smith, John P.'
+
+    assert expected == normalize_name('Smith, John P.')
+    assert expected == normalize_name('Smith, John P. ')
+    assert expected == normalize_name('Smith, John P ')
+
+
+def test_normalize_name_handles_names_with_dots_initials():
+    expected = 'Smith, J.P.'
+
+    assert expected == normalize_name('Smith, J. P.')
+    assert expected == normalize_name('Smith, J.P.')
+    assert expected == normalize_name('Smith, J.P. ')
+    assert expected == normalize_name('Smith, J. P. ')
+
+
+def test_normalize_name_handles_names_with_spaces():
+    expected = 'Smith, J.P.'
+
+    assert expected == normalize_name('Smith, J P ')
+    assert expected == normalize_name('Smith, J P')
+
+
+def test_normalize_name_handles_names_with_several_last_names():
+    expected = 'Smith Davis, J.P.'
+
+    assert expected == normalize_name('Smith Davis, J.P.')
+
+
+def test_normalize_name_handles_jimmy():  # http://jimmy.pink
+    expected = 'Jimmy'
+
+    assert expected == normalize_name('Jimmy')
+
+
+def test_normalize_name_handles_unicode():
+    expected = u'蕾拉'
+
+    assert expected == normalize_name(u'蕾拉')
+
+
+def test_normalize_name_converts_unicode_apostrophe_to_normal_apostrophe():
+    expected = u'M\'Gregor, Jimmy'
+
+    assert expected == normalize_name(u'M’Gregor, Jimmy')
+
+
+@pytest.mark.parametrize("input_author_name,expected", [
+    ('Smith, John Jr', 'Smith, John, Jr.'),
+    ('Smith, John Jr.', 'Smith, John, Jr.'),
+    ('Smith, John III', 'Smith, John, III'),
+    ('Smith, John iii', 'Smith, John, III'),
+    ('Smith, John VIII', 'Smith, John, VIII'),
+    ('Smith, John viii', 'Smith, John, VIII'),
+    ('Smith, John IV', 'Smith, John, IV'),
+    ('Smith, John iv', 'Smith, John, IV'),
+])
+def test_normalize_name_handles_suffixes(input_author_name, expected):
+    assert normalize_name(input_author_name) == expected
+
+
+@pytest.mark.parametrize("input_author_name,expected", [
+    ('Sir John Smith', 'Smith, John'),
+    ('Bao, Hon', 'Bao, Hon'),
+])
+def test_normalize_name_handles_titles(input_author_name, expected):
+    assert normalize_name(input_author_name) == expected
+
+
+def test_generate_name_variations_with_two_non_lastnames():
+    name = 'Ellis, John Richard'
+    expected_name_variations = {
+        'Ellis J',
+        'Ellis J R',
+        'Ellis J Richard',
+        'Ellis John',
+        'Ellis John R',
+        'Ellis John Richard',
+        'Ellis R',
+        'Ellis Richard',
+        'Ellis, J',
+        'Ellis, J R',
+        'Ellis, J Richard',
+        'Ellis, John',
+        'Ellis, John R',
+        'Ellis, John Richard',
+        'Ellis, R',
+        'Ellis, Richard',
+        'J Ellis',
+        'J R Ellis',
+        'J Richard Ellis',
+        'John Ellis',
+        'John R Ellis',
+        'John Richard Ellis',
+        'R Ellis',
+        'Richard Ellis',
+        'J, Ellis',
+        'J R, Ellis',
+        'J Richard, Ellis',
+        'John, Ellis',
+        'John R, Ellis',
+        'John Richard, Ellis',
+        'R, Ellis',
+        'Richard, Ellis',
+    }
+
+    result = generate_name_variations(name)
+
+    assert set(result) == expected_name_variations
+
+
+def test_generate_name_variations_with_two_lastnames():
+    name = u'Caro Estevez, David'
+    expected = {
+        # Lastnames first and then non lastnames
+        u'Caro Estevez D',
+        u'Caro Estevez David',
+        u'Caro Estevez, D',
+        u'Caro Estevez, David',
+        u'Caro D',
+        u'Caro, D',
+        u'Caro David',
+        u'Caro, David',
+        # Non lastnames first and then lastnames
+        u'D Caro',
+        u'D, Caro',
+        u'D Caro Estevez',
+        u'D, Caro Estevez',
+        u'David Caro',
+        u'David, Caro',
+        u'David Caro Estevez',
+        u'David, Caro Estevez',
+    }
+
+    result = generate_name_variations(name)
+
+    assert set(result) == expected
+
+
+def test_generate_name_variations_with_three_lastnames_dashed_ignores_the_dash():
+    name = u'Caro-Estévez Martínez, David'
+    expected = {
+        # Lastnames first and then non lastnames
+        u'Caro Estevez Martinez D',
+        u'Caro Estevez Martinez David',
+        u'Caro Estevez Martinez, D',
+        u'Caro Estevez Martinez, David',
+        u'Caro D',
+        u'Caro, D',
+        u'Caro David',
+        u'Caro, David',
+        # Non lastnames first and then lastnames
+        u'D Caro',
+        u'D, Caro',
+        u'D Caro Estevez Martinez',
+        u'D, Caro Estevez Martinez',
+        u'David Caro',
+        u'David, Caro',
+        u'David Caro Estevez Martinez',
+        u'David, Caro Estevez Martinez',
+    }
+
+    result = generate_name_variations(name)
+
+    assert set(result) == expected
+
+
+def test_generate_name_variations_with_firstname_as_initial():
+    name = 'Smith, J'
+    expected = {
+        # Lastnames first and then non lastnames
+        'Smith J',
+        'Smith, J',
+        # Non lastnames first and then lastnames
+        'J Smith',
+        'J, Smith',
+    }
+
+    result = generate_name_variations(name)
+
+    assert set(result) == expected
+
+
+def test_generate_name_variations_with_only_one_name():
+    name = 'Jimmy'
+    expected = {
+        'Jimmy',
+    }
+
+    result = generate_name_variations(name)
+
+    assert set(result) == expected


### PR DESCRIPTION
Aims to centralize name handling in Inspire, specifically for names normalization and generation of variations.