### PR TITLE
name: various fixes to generate_name_variations

### DIFF
--- a/inspire_utils/name.py
+++ b/inspire_utils/name.py
@@ -191,7 +191,7 @@ def _generate_lastnames_variations(lastnames):
     """Generate variations for lastnames.
 
     Note:
-        This method follows the assumption that the first last
+        This method follows the assumption that the first last name is the main one.
         E.g. For 'Caro Estevez', this method generates: ['Caro', 'Caro Estevez'].
         In the case the lastnames are dashed, it splits them in two.
     """
@@ -221,14 +221,13 @@ def generate_name_variations(name):
         Uses `unidecode` for doing unicode characters transliteration to ASCII ones. This was chosen so that we can map
         both full names of authors in HEP records and user's input to the same space and thus make exact queries work.
     """
-    def _update_name_variations_with_product(set_a, set_b, non_lastnames_idx_in_product_result):
+    def _update_name_variations_with_product(set_a, set_b):
         name_variations.update([
             unidecode(
                 (names_variation[0] + separator + names_variation[1]).strip(''.join(_LASTNAME_NON_LASTNAME_SEPARATORS))
             )
             for names_variation
             in product(set_a, set_b)
-            if names_variation[non_lastnames_idx_in_product_result]  # Don't generate only lastnames as variations.
             for separator
             in _LASTNAME_NON_LASTNAME_SEPARATORS
         ])
@@ -256,9 +255,9 @@ def generate_name_variations(name):
     lastnames_variations = _generate_lastnames_variations(parsed_name.last_list)
 
     # Create variations where lastnames comes first and is separated from non lastnames either by space or comma.
-    _update_name_variations_with_product(lastnames_variations, non_lastnames_variations, 1)
+    _update_name_variations_with_product(lastnames_variations, non_lastnames_variations)
 
     # Second part of transformations - having the lastnames in the end.
-    _update_name_variations_with_product(non_lastnames_variations, lastnames_variations, 0)
+    _update_name_variations_with_product(non_lastnames_variations, lastnames_variations)
 
     return list(name_variations)

--- a/inspire_utils/name.py
+++ b/inspire_utils/name.py
@@ -184,7 +184,7 @@ def _generate_non_lastnames_variations(non_lastnames):
         non_lastnames[idx] = (u'', non_lastname[0], non_lastname)
 
     # Generate the cartesian product of the transformed non lastnames and flatten them.
-    return [(u' '.join(variation)).strip() for variation in product(*non_lastnames)]
+    return [(u' '.join(filter(None, variation))).strip() for variation in product(*non_lastnames)]
 
 
 def _generate_lastnames_variations(lastnames):

--- a/inspire_utils/name.py
+++ b/inspire_utils/name.py
@@ -184,7 +184,10 @@ def _generate_non_lastnames_variations(non_lastnames):
         non_lastnames[idx] = (u'', non_lastname[0], non_lastname)
 
     # Generate the cartesian product of the transformed non lastnames and flatten them.
-    return [(u' '.join(filter(None, variation))).strip() for variation in product(*non_lastnames)]
+    return [
+        (u' '.join(var_elem for var_elem in variation if var_elem)).strip()
+        for variation in product(*non_lastnames)
+    ]
 
 
 def _generate_lastnames_variations(lastnames):
@@ -239,7 +242,15 @@ def generate_name_variations(name):
         return [name]
 
     name_variations = set()
-    non_lastnames = parsed_name.first_list + parsed_name.middle_list
+
+    # We need to filter out empty entries, since HumanName for this name `Perelstein,, Maxim` returns a first_list with
+    # an empty string element.
+    non_lastnames = [
+        non_lastname
+        for non_lastname
+        in parsed_name.first_list + parsed_name.middle_list + parsed_name.suffix_list
+        if non_lastname
+    ]
 
     # This is needed because due to erroneous data (e.g. having many authors in a single authors field) ends up
     # requiring a lot of memory (due to combinatorial expansion of all non lastnames).

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ install_requires = [
 docs_require = []
 
 tests_require = [
+    'mock~=2.0,>=2.0.0',
     'flake8-future-import~=0.0,>=0.4.3',
     'pytest~=3.0,>=3.2.0',
     'pytest-cov~=2.0,>=2.5.1',

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -115,6 +115,7 @@ def test_normalize_name_handles_titles(input_author_name, expected):
 def test_generate_name_variations_with_two_non_lastnames():
     name = 'Ellis, John Richard'
     expected_name_variations = {
+        'Ellis',
         'Ellis J',
         'Ellis J R',
         'Ellis J Richard',
@@ -157,6 +158,9 @@ def test_generate_name_variations_with_two_non_lastnames():
 def test_generate_name_variations_with_two_lastnames():
     name = u'Caro Estevez, David'
     expected = {
+        # Lastnames only
+        'Caro',
+        'Caro Estevez',
         # Lastnames first and then non lastnames
         u'Caro Estevez D',
         u'Caro Estevez David',
@@ -185,6 +189,9 @@ def test_generate_name_variations_with_two_lastnames():
 def test_generate_name_variations_with_three_lastnames_dashed_ignores_the_dash():
     name = u'Caro-Estévez Martínez, David'
     expected = {
+        # Lastnames only
+        'Caro',
+        'Caro Estevez Martinez',
         # Lastnames first and then non lastnames
         u'Caro Estevez Martinez D',
         u'Caro Estevez Martinez David',
@@ -213,6 +220,8 @@ def test_generate_name_variations_with_three_lastnames_dashed_ignores_the_dash()
 def test_generate_name_variations_with_firstname_as_initial():
     name = 'Smith, J'
     expected = {
+        # Lastname only
+        'Smith',
         # Lastnames first and then non lastnames
         'Smith J',
         'Smith, J',
@@ -254,14 +263,18 @@ def test_generate_name_variations_with_many_names_defers_generating_variations()
 def test_generate_name_variations_capitalizes_first_letters():
     name = 'mele, salvatore'
     expected = {
+        # Lastname only
+        'Mele',
+        # Lastnames first and then non lastnames
         'Mele S',
-        'Mele, Salvatore',
-        'Salvatore Mele',
         'Mele, S',
-        'S Mele',
         'Mele Salvatore',
+        'Mele, Salvatore',
+        # Non lastnames first and then lastnames
+        'Salvatore Mele',
+        'Salvatore, Mele',
+        'S Mele',
         'S, Mele',
-        'Salvatore, Mele'
     }
 
     result = generate_name_variations(name)

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -23,6 +23,7 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+from mock import patch
 
 from inspire_utils.name import normalize_name, generate_name_variations
 
@@ -229,6 +230,38 @@ def test_generate_name_variations_with_only_one_name():
     name = 'Jimmy'
     expected = {
         'Jimmy',
+    }
+
+    result = generate_name_variations(name)
+
+    assert set(result) == expected
+
+
+def test_generate_name_variations_with_many_names_defers_generating_variations():
+    import logging
+    logger = logging.getLogger('inspire_utils.name')
+    with patch.object(logger, 'error') as mock_error:
+        many_names_as_one_author = 'Tseng, Farrukh Azfar Todd Huffman Thilo Pauly'
+
+        result = generate_name_variations(many_names_as_one_author)
+
+        assert result == [many_names_as_one_author]
+
+        args, _ = mock_error.call_args
+        assert args[0].startswith('Skipping name variations generation - too many names')
+
+
+def test_generate_name_variations_capitalizes_first_letters():
+    name = 'mele, salvatore'
+    expected = {
+        'Mele S',
+        'Mele, Salvatore',
+        'Salvatore Mele',
+        'Mele, S',
+        'S Mele',
+        'Mele Salvatore',
+        'S, Mele',
+        'Salvatore, Mele'
     }
 
     result = generate_name_variations(name)

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -155,6 +155,14 @@ def test_generate_name_variations_with_two_non_lastnames():
     assert set(result) == expected_name_variations
 
 
+def test_generate_name_variations_with_more_than_two_non_lastnames_does_not_add_extra_spaces():
+    name = 'Ellis, John Richard Philip'
+
+    result = generate_name_variations(name)
+
+    assert 'Ellis, John  Philip' not in set(result)
+
+
 def test_generate_name_variations_with_two_lastnames():
     name = u'Caro Estevez, David'
     expected = {

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -288,3 +288,25 @@ def test_generate_name_variations_capitalizes_first_letters():
     result = generate_name_variations(name)
 
     assert set(result) == expected
+
+
+def test_generate_name_variations_works_with_two_consecutive_commas():
+    name = 'Perelstein,, Maxim'
+    expected = {
+        # Lastname only
+        'Perelstein',
+        # Lastnames first and then non lastnames
+        'Perelstein M',
+        'Perelstein, M',
+        'Perelstein Maxim',
+        'Perelstein, Maxim',
+        # Non lastnames first and then lastnames
+        'Maxim Perelstein',
+        'Maxim, Perelstein',
+        'M Perelstein',
+        'M, Perelstein',
+    }
+
+    result = generate_name_variations(name)
+
+    assert set(result) == expected


### PR DESCRIPTION
Addresses:

- https://github.com/inspirehep/inspire-next/issues/2945 Skip generation of name variations when names are too many. This happens usually on erroneous data. 
- Capitalizing all names, so that `mele, salvatore` returns results for `Mele, Salvatore` (currently returns nothing).
- Add only lastnames as a variation. 
It is required for being able to search only with lastnames. Currently a search for `Mele` returns nothing since we're being too strict on filtering out records whose name variations don't match the name variations of the query.
- [minor] Stripping non lastname variations in cases where non lastnames are more than two. This happened because we generate an empty name variation and thus the cartesian product result contains extraneous whitespace when middle (as in order) names are empty strings.
- Filter out empty entries on `non_lastnames` (addresses https://sentry.inspirehep.net/inspire-sentry/prod/issues/166/).
With this input `'Perelstein,, Maxim'`, `HumanName` creates an empty string element into the `first_list` (it seems that it shouldn't, will look into it).
Additionally, address handling of that name, since the first name gets included into the `suffix_list`. So, now `non_lastnames` is initiallized also by the `suffix_list`.