### PR TITLE
global: add logging module

### DIFF
--- a/inspire_utils/logging.py
+++ b/inspire_utils/logging.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+from __future__ import absolute_import, division, print_function
+
+import logging
+
+
+class StackTraceLogger(object):
+    def __init__(self, logger):
+        self.logger = logger
+
+    def __getattr__(self, item):
+        """Preserve Python logger interface."""
+        return getattr(self.logger, item)
+
+    def error(self, message, *args, **kwargs):
+        """Log error with stack trace and locals information.
+
+        By default, enables stack trace information in logging messages, so that stacktrace and locals appear in Sentry.
+        """
+        kwargs.setdefault('extra', {}).setdefault('stack', True)
+        return self.logger.error(message, *args, **kwargs)
+
+
+def getStackTraceLogger(*args, **kwargs):
+    """Returns a :class:`StackTrace` logger that wraps a Python logger instance."""
+    logger = logging.getLogger(*args, **kwargs)
+    return StackTraceLogger(logger)

--- a/inspire_utils/name.py
+++ b/inspire_utils/name.py
@@ -24,13 +24,14 @@ from __future__ import absolute_import, division, print_function
 
 from itertools import product
 
-import logging
 from nameparser import HumanName
 from nameparser.config import Constants
 import six
 from unidecode import unidecode
 
-LOGGER = logging.getLogger(__name__)
+from .logging import getStackTraceLogger
+
+LOGGER = getStackTraceLogger(__name__)
 
 _LASTNAME_NON_LASTNAME_SEPARATORS = [u' ', u', ']
 _NAMES_MAX_NUMBER_THRESHOLD = 5
@@ -256,9 +257,7 @@ def generate_name_variations(name):
     # requiring a lot of memory (due to combinatorial expansion of all non lastnames).
     # The policy is to use the input as a name variation, since this data will have to be curated.
     if len(non_lastnames) > _NAMES_MAX_NUMBER_THRESHOLD or len(parsed_name.last_list) > _NAMES_MAX_NUMBER_THRESHOLD:
-        LOGGER.error('Skipping name variations generation - too many names in: "%s"', name, extra={
-            'stack': True,
-        })
+        LOGGER.error('Skipping name variations generation - too many names in: "%s"', name)
         return [name]
 
     non_lastnames_variations = \


### PR DESCRIPTION
Add `log_error_with_extra` helper which enables by default, stacktrace
and locals information. Using this, the aforementioned information
appear in Sentry, even if the log comes from a dependency.

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>

When combined with https://github.com/inspirehep/inspire-next/pull/2952, Sentry will receive locals and stacktrace from code running in a dependency.