### PR TITLE
name: provide API of HumanName

### DIFF
--- a/inspire_utils/name.py
+++ b/inspire_utils/name.py
@@ -74,13 +74,53 @@ class ParsedName(object):
         """
         if not constants:
             constants = ParsedName.constants
-        self.parsed_name = HumanName(name, constants=constants)
+
+        self._parsed_name = HumanName(name, constants=constants)
+
+    def __len__(self):
+        return len(self._parsed_name)
 
     def __repr__(self):
-        return repr(self.parsed_name)
+        return repr(self._parsed_name)
 
     def __str__(self):
-        return str(self.parsed_name)
+        return str(self._parsed_name)
+
+    @property
+    def title(self):
+        return self._parsed_name.title
+
+    @property
+    def first(self):
+        return self._parsed_name.first
+
+    @property
+    def first_list(self):
+        return self._parsed_name.first_list
+
+    @property
+    def middle(self):
+        return self._parsed_name.middle
+
+    @property
+    def middle_list(self):
+        return self._parsed_name.middle_list
+
+    @property
+    def last(self):
+        return self._parsed_name.last
+
+    @property
+    def last_list(self):
+        return self._parsed_name.last_list
+
+    @property
+    def suffix(self):
+        return self._parsed_name.suffix
+
+    @property
+    def suffix_list(self):
+        return self._parsed_name.suffix_list
 
     @classmethod
     def loads(cls, name):
@@ -125,8 +165,8 @@ class ParsedName(object):
                        for letters in suffix.upper())
 
         # Create first and middle
-        first_name = _ensure_dotted_initials(self.parsed_name.first)
-        middle_name = _ensure_dotted_initials(self.parsed_name.middle)
+        first_name = _ensure_dotted_initials(self.first)
+        middle_name = _ensure_dotted_initials(self.middle)
 
         if _is_initial(first_name) and _is_initial(middle_name):
             normalized_names = u'{first_name}{middle_name}'
@@ -138,13 +178,13 @@ class ParsedName(object):
             middle_name=middle_name,
         )
 
-        if _is_roman_numeral(self.parsed_name.suffix):
-            suffix = self.parsed_name.suffix.upper()
+        if _is_roman_numeral(self.suffix):
+            suffix = self.suffix.upper()
         else:
-            suffix = _ensure_dotted_suffixes(self.parsed_name.suffix)
+            suffix = _ensure_dotted_suffixes(self.suffix)
 
         final_name = u', '.join(
-            part for part in (self.parsed_name.last, normalized_names.strip(), suffix)
+            part for part in (self.last, normalized_names.strip(), suffix)
             if part)
 
         # Replace unicode curly apostrophe to normal apostrophe.
@@ -236,7 +276,7 @@ def generate_name_variations(name):
             in _LASTNAME_NON_LASTNAME_SEPARATORS
         ])
 
-    parsed_name = ParsedName.loads(name).parsed_name
+    parsed_name = ParsedName.loads(name)
 
     # Handle rare-case of single-name
     if len(parsed_name) == 1:

--- a/inspire_utils/name.py
+++ b/inspire_utils/name.py
@@ -67,7 +67,7 @@ class ParsedName(object):
         """Create a ParsedName instance.
 
         Args:
-            name (str): The name to be parsed (must be non empty nor None).
+            name (six.text_type): The name to be parsed (must be non empty nor None).
             constants (:class:`nameparser.config.Constants`): Configuration for `HumanName` instantiation.
                 (Can be None, if provided it overwrites the default one generated in
                 :method:`prepare_nameparser_constants`.)
@@ -76,6 +76,12 @@ class ParsedName(object):
             constants = ParsedName.constants
 
         self._parsed_name = HumanName(name, constants=constants)
+
+        # In the case of one name part, i.e. only lastname, name parser adds the name part in one of the first, middle,
+        # suffix fields (depending on input). For our use-case if a user types a name, usually would be a lastname.
+        if len(name.split()) == 1:
+            self._parsed_name.last = self._parsed_name.first + self._parsed_name.middle + self._parsed_name.suffix
+            self._parsed_name.first = ''
 
     def __len__(self):
         return len(self._parsed_name)

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 from mock import patch
 
-from inspire_utils.name import normalize_name, generate_name_variations
+from inspire_utils.name import normalize_name, generate_name_variations, ParsedName
 
 
 def test_normalize_name_full():
@@ -321,3 +321,11 @@ def test_generate_name_variations_works_with_two_consecutive_commas():
     result = generate_name_variations(name)
 
     assert set(result) == expected
+
+
+def test_parsed_name_creates_lastname_with_only_on_name_part():
+    name = u'ellis'
+    parsed_name = ParsedName(name)
+
+    assert not all([parsed_name.first, parsed_name.middle, parsed_name.suffix])
+    assert parsed_name.last == name


### PR DESCRIPTION
Firstly, following the facade pattern this PR makes name module provide a subset of the HumanName interface.

Secondly, in the case of single part names, HumanName assigns them (depending on input) in either its first, middle, suffix fields. For our use case, if users type single name part, it will be the lastname.