### PR TITLE
name: ParsedName improvements

### DIFF
--- a/inspire_utils/name.py
+++ b/inspire_utils/name.py
@@ -83,6 +83,9 @@ class ParsedName(object):
             self._parsed_name.last = self._parsed_name.first + self._parsed_name.middle + self._parsed_name.suffix
             self._parsed_name.first = ''
 
+    def __iter__(self):
+        return self._parsed_name
+
     def __len__(self):
         return len(self._parsed_name)
 

--- a/inspire_utils/name.py
+++ b/inspire_utils/name.py
@@ -67,7 +67,7 @@ class ParsedName(object):
         """Create a ParsedName instance.
 
         Args:
-            name (six.text_type): The name to be parsed (must be non empty nor None).
+            name (str): The name to be parsed (must be non empty nor None).
             constants (:class:`nameparser.config.Constants`): Configuration for `HumanName` instantiation.
                 (Can be None, if provided it overwrites the default one generated in
                 :method:`prepare_nameparser_constants`.)
@@ -77,12 +77,6 @@ class ParsedName(object):
 
         self._parsed_name = HumanName(name, constants=constants)
         self._parsed_name.capitalize()
-
-        # In the case of one name part, i.e. only lastname, name parser adds the name part in one of the first, middle,
-        # suffix fields (depending on input). For our use-case if a user types a name, usually would be a lastname.
-        if len(name.split()) == 1:
-            self._parsed_name.last = self._parsed_name.first + self._parsed_name.middle + self._parsed_name.suffix
-            self._parsed_name.first = ''
 
     def __iter__(self):
         return self._parsed_name

--- a/inspire_utils/name.py
+++ b/inspire_utils/name.py
@@ -76,6 +76,7 @@ class ParsedName(object):
             constants = ParsedName.constants
 
         self._parsed_name = HumanName(name, constants=constants)
+        self._parsed_name.capitalize()
 
         # In the case of one name part, i.e. only lastname, name parser adds the name part in one of the first, middle,
         # suffix fields (depending on input). For our use-case if a user types a name, usually would be a lastname.
@@ -230,7 +231,6 @@ def _generate_non_lastnames_variations(non_lastnames):
     # Generate name transformations in place for all non lastnames. Transformations include:
     # 1. Drop non last name, 2. use initial, 3. use full non lastname
     for idx, non_lastname in enumerate(non_lastnames):
-        non_lastname = non_lastname.capitalize()
         non_lastnames[idx] = (u'', non_lastname[0], non_lastname)
 
     # Generate the cartesian product of the transformed non lastnames and flatten them.
@@ -251,7 +251,7 @@ def _generate_lastnames_variations(lastnames):
     if not lastnames:
         return []
 
-    split_lastnames = [split_lastname.capitalize() for lastname in lastnames for split_lastname in lastname.split('-')]
+    split_lastnames = [split_lastname for lastname in lastnames for split_lastname in lastname.split('-')]
 
     lastnames_variations = [split_lastnames[0]]  # Always have the first lastname as a variation.
     if len(split_lastnames) > 1:
@@ -289,7 +289,7 @@ def generate_name_variations(name):
 
     # Handle rare-case of single-name
     if len(parsed_name) == 1:
-        return [name.capitalize()]
+        return [parsed_name.dumps()]
 
     name_variations = set()
 

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -324,8 +324,10 @@ def test_generate_name_variations_works_with_two_consecutive_commas():
 
 
 def test_parsed_name_creates_lastname_with_only_on_name_part():
-    name = u'ellis'
+    name = 'ellis'
+    expected_name = 'Ellis'
+
     parsed_name = ParsedName(name)
 
     assert not all([parsed_name.first, parsed_name.middle, parsed_name.suffix])
-    assert parsed_name.last == name
+    assert parsed_name.last == expected_name

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -25,7 +25,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 from mock import patch
 
-from inspire_utils.name import normalize_name, generate_name_variations, ParsedName
+from inspire_utils.name import normalize_name, generate_name_variations
 
 
 def test_normalize_name_full():
@@ -321,13 +321,3 @@ def test_generate_name_variations_works_with_two_consecutive_commas():
     result = generate_name_variations(name)
 
     assert set(result) == expected
-
-
-def test_parsed_name_creates_lastname_with_only_on_name_part():
-    name = 'ellis'
-    expected_name = 'Ellis'
-
-    parsed_name = ParsedName(name)
-
-    assert not all([parsed_name.first, parsed_name.middle, parsed_name.suffix])
-    assert parsed_name.last == expected_name


### PR DESCRIPTION
Some imrpovements on ParsedName:
- supporting iteration on its parts (first, last, middle, etc.).
- centralizing capitalization and delegating it to HumanName ([rel. docs](http://nameparser.readthedocs.io/en/latest/usage.html#capitalization-support)). 
@michamos is this ok for the `normalize_name` usecase? 

- reverting the "name: make firstname last with one name part input", as it's not needed. (If it is, solution is [here](https://github.com/inspirehep/inspire-utils/pull/29#issuecomment-349621850)).