### PR TITLE
urls: create URL utils

### DIFF
--- a/inspire_utils/urls.py
+++ b/inspire_utils/urls.py
@@ -25,7 +25,7 @@
 from __future__ import absolute_import, division, print_function
 
 from six import text_type
-from six.moves.urllib.parse import urlsplit, urlunsplit
+from six.moves.urllib.parse import urlsplit, urlunsplit, SplitResult
 
 
 def ensure_scheme(url, default_scheme='http'):
@@ -38,11 +38,17 @@ def ensure_scheme(url, default_scheme='http'):
     Returns:
         string: URL with a scheme
     """
-    parsed = urlsplit(url)
-    if not parsed.scheme and not parsed.netloc:
-        url = '//%s' % url
+    parsed = urlsplit(url, scheme=default_scheme)
+    if not parsed.netloc:
+        parsed = SplitResult(
+            scheme=parsed.scheme,
+            netloc=parsed.path,
+            path='',
+            query=parsed.query,
+            fragment=parsed.fragment
+        )
 
-    return urlunsplit(urlsplit(url, scheme=default_scheme))
+    return urlunsplit(parsed)
 
 
 def record_url_by_pattern(pattern, recid):

--- a/inspire_utils/urls.py
+++ b/inspire_utils/urls.py
@@ -62,5 +62,4 @@ def record_url_by_pattern(pattern, recid):
     Returns:
         string: built record URL
     """
-    recid = text_type(recid)
     return text_type(ensure_scheme(pattern)).format(recid=recid)

--- a/inspire_utils/urls.py
+++ b/inspire_utils/urls.py
@@ -24,27 +24,25 @@
 
 from __future__ import absolute_import, division, print_function
 
-import re
-
 from six import text_type
+from six.moves.urllib.parse import urlsplit, urlunsplit
 
 
-def ensure_scheme(url, default_schema='http'):
+def ensure_scheme(url, default_scheme='http'):
     """Adds a scheme to a url if not present.
 
-    Scheme is defined in section 3.1 of http://www.ietf.org/rfc/rfc2396.txt
-
     Args:
-        url (string): a url
-        default_schema (string): a scheme to be added
+        url (string): a url, assumed to start with netloc
+        default_scheme (string): a scheme to be added
 
     Returns:
         string: URL with a scheme
     """
-    if not re.match(r'^[a-zA-Z][a-zA-Z+\-.0-9]*://', url):
-        url = '%s://%s' % (default_schema, url)
+    parsed = urlsplit(url)
+    if not parsed.scheme and not parsed.netloc:
+        url = '//%s' % url
 
-    return url
+    return urlunsplit(urlsplit(url, scheme=default_scheme))
 
 
 def record_url_by_pattern(pattern, recid):

--- a/inspire_utils/urls.py
+++ b/inspire_utils/urls.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""URL-related utils."""
+
+from __future__ import absolute_import, division, print_function
+
+import re
+
+from six import text_type
+
+
+def ensure_scheme(url, default_schema='http'):
+    """Adds a scheme to a url if not present.
+
+    Scheme is defined in section 3.1 of http://www.ietf.org/rfc/rfc2396.txt
+
+    Args:
+        url (string): a url
+        default_schema (string): a scheme to be added
+
+    Returns:
+        string: URL with a scheme
+    """
+    if not re.match(r'^[a-zA-Z][a-zA-Z+\-.0-9]*://', url):
+        url = '%s://%s' % (default_schema, url)
+
+    return url
+
+
+def record_url_by_pattern(pattern, recid):
+    """Get a URL to a record constructing it from a pattern.
+
+    Args:
+        pattern (string): a URL pattern as a format-friendly string with a
+            `recid` field
+        recid (Union[string, int]): record ID
+
+    Returns:
+        string: built record URL
+    """
+    recid = text_type(recid)
+    return text_type(ensure_scheme(pattern)).format(recid=recid)

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -20,7 +20,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-"""Description"""
+"""Tests for URL utils."""
 
 from __future__ import absolute_import, division, print_function
 
@@ -48,7 +48,7 @@ from inspire_utils.urls import ensure_scheme, record_url_by_pattern
 )
 def test_ensure_scheme(url, scheme, expected):
     if scheme:
-        assert ensure_scheme(url, default_schema=scheme) == expected
+        assert ensure_scheme(url, default_scheme=scheme) == expected
     else:
         assert ensure_scheme(url) == expected
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2018 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+
+"""Description"""
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from inspire_utils.urls import ensure_scheme, record_url_by_pattern
+
+
+@pytest.mark.parametrize(
+    'url,scheme,expected',
+    [
+        ('http://inspirehep.net', None, 'http://inspirehep.net'),
+        ('http://inspirehep.net', 'https', 'http://inspirehep.net'),
+        ('inspirehep.net', None, 'http://inspirehep.net'),
+        ('inspirehep.net', 'custom+http', 'custom+http://inspirehep.net'),
+        (u'ïnśpirę.nẽt', 'https', u'https://ïnśpirę.nẽt'),
+    ],
+    ids=[
+        'scheme already present',
+        'scheme present, ignores default',
+        'add default scheme',
+        'add custom scheme',
+        'unicode',
+    ]
+)
+def test_ensure_scheme(url, scheme, expected):
+    if scheme:
+        assert ensure_scheme(url, default_schema=scheme) == expected
+    else:
+        assert ensure_scheme(url) == expected
+
+
+@pytest.mark.parametrize(
+    'pattern,recid,expected',
+    [
+        (
+            'http://inspirehep.net/record/{recid}',
+            123,
+            'http://inspirehep.net/record/123',
+        ),
+        (
+            'inspirehep.net/record/{recid}',
+            '4567',
+            'http://inspirehep.net/record/4567',
+        ),
+        (
+            u'http://ïnśpirę.nẽt/record/{recid}',
+            123,
+            u'http://ïnśpirę.nẽt/record/123',
+        ),
+    ],
+    ids=[
+        'integer recid, scheme already present',
+        'string recid, no scheme',
+        'unicode url',
+    ]
+)
+def test_record_url_by_pattern(pattern, recid, expected):
+    assert record_url_by_pattern(pattern, recid) == expected

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -37,6 +37,11 @@ from inspire_utils.urls import ensure_scheme, record_url_by_pattern
         ('inspirehep.net', None, 'http://inspirehep.net'),
         ('inspirehep.net', 'custom+http', 'custom+http://inspirehep.net'),
         (u'ïnśpirę.nẽt', 'https', u'https://ïnśpirę.nẽt'),
+        ('http://inspirehep.net/path', None, 'http://inspirehep.net/path'),
+        ('inspirehep.net/path', None, 'http://inspirehep.net/path'),
+        ('//inspirehep.net/path', None, 'http://inspirehep.net/path'),
+        ('/path/somewhere', None, 'http:///path/somewhere'),
+        ('http:///path/somewhere', None, 'http:///path/somewhere'),
     ],
     ids=[
         'scheme already present',
@@ -44,6 +49,11 @@ from inspire_utils.urls import ensure_scheme, record_url_by_pattern
         'add default scheme',
         'add custom scheme',
         'unicode',
+        'with scheme and with path',
+        'no scheme, with path',
+        'explicit netloc',
+        'with scheme, no netloc',
+        'without scheme, no netloc',
     ]
 )
 def test_ensure_scheme(url, scheme, expected):


### PR DESCRIPTION
# Description

This introduces a couple of URL utils:

- `ensure_scheme`: similar functionality is reused in different parts of INSPIRE already, this utils function will help to reduce code duplication
- `record_url_by_pattern`: builds a URL for a record from a pattern string like `inspirehep.net/record/{recid}`. This will then be used in inspirehep/inspire-next#3204, while being configuration-agnostic

# Motivation

Currently we have no centralized way of creating production record URLs, this is what inspirehep/inspire-next#3204 is trying to introduce. However I ran into an issue where, by design, `OrcidConverter` is to be kept separate from the flask app. It will however be able to use `record_url_by_pattern` in conjuntion with passing a URL pattern to it, as discussed with @drjova.