### PR TITLE
record: fix get_value bug on inner string values

### DIFF
--- a/inspire_utils/record.py
+++ b/inspire_utils/record.py
@@ -27,7 +27,7 @@ from six import string_types
 import re
 
 
-SPLIT_KEY_PATTERN = re.compile('\.|\[')
+SPLIT_KEY_PATTERN = re.compile(r'\.|\[')
 
 
 def get_value(record, key, default=None):

--- a/inspire_utils/record.py
+++ b/inspire_utils/record.py
@@ -22,6 +22,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+from six import string_types
+
 import re
 
 
@@ -43,7 +45,9 @@ def get_value(record, key, default=None):
             1000000 loops, best of 3: 598 ns per loop
     """
     def getitem(k, v, default):
-        if isinstance(v, dict):
+        if isinstance(v, string_types):
+            raise KeyError
+        elif isinstance(v, dict):
             return v[k]
         elif ']' in k:
             k = k[:-1].replace('n', '-1')

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,4 +31,4 @@ include = inspire_utils/*.py
 addopts = --cov=inspire_utils --cov-report=term-missing:skip-covered
 
 [flake8]
-ignore = *.py E501 FI12 FI14 FI15 FI16 FI17 FI50 FI51 FI53
+ignore = *.py E501 FI12 FI14 FI15 FI16 FI17 FI50 FI51 FI53 W504

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -73,6 +73,16 @@ def test_get_value_allows_slices_in_paths():
     assert expected == result
 
 
+def test_get_value_returns_none_if_inner_key_does_not_exist_on_string():
+    record = {
+        'foo': 'bar'
+    }
+
+    result = get_value(record, 'foo.value')
+
+    assert result is None
+
+
 def test_get_values_for_schema():
     elements = [
         {'schema': 'good', 'value': 'first'},


### PR DESCRIPTION
get_value was raising `maximum recursion depth exceeded`, because while
trying to get an inner key from a string value.

(Didn't put message for the exception since it's handled by the caller already)