### PR TITLE
name: add check if name is empty string in first_initials_list

### DIFF
--- a/inspire_utils/name.py
+++ b/inspire_utils/name.py
@@ -104,7 +104,7 @@ class ParsedName(object):
     @property
     def first_initials_list(self):
         names = self.first_list
-        return [(name[0] + u'.') for name in names]
+        return [(name[0] + u'.') for name in names if name]
 
     @property
     def first_list(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,4 +31,4 @@ include = inspire_utils/*.py
 addopts = --cov=inspire_utils --cov-report=term-missing:skip-covered
 
 [flake8]
-ignore = *.py E501 FI12 FI14 FI15 FI16 FI17 FI50 FI51 FI53 W504
+ignore = *.py E501 FI12 FI14 FI15 FI16 FI17 FI50 FI51 FI53 W504 FI18

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -407,6 +407,12 @@ def test_format_author_name_with_initials():
     assert expected == format_name('Lieber, Stanley Martin', initials_only=True)
 
 
+def test_format_author_name_with_initials_with_all_caps_name():
+    expected = 'T. S. Holland'
+
+    assert expected == format_name('HOLLAND, TOM STANLEY', initials_only=True)
+
+
 def test_parsed_name_initials():
     parsed_name = ParsedName("Holland, Tom Stanley")
     expected = "T. S."


### PR DESCRIPTION
* There needs to be a check if name is empty string because _parsed_name.middle_list contains an empty string when the full name is all lower case or all upper case and this was causing an index out of range
* INSPIR-2631