### PR TITLE
date: change year format for year only dates and add separate function to add missing month and day

### DIFF
--- a/inspire_utils/date.py
+++ b/inspire_utils/date.py
@@ -191,8 +191,8 @@ class PartialDate(object):
         if not self.month:
             return dates.format_date(datetime.date(self.year, 1, 1), 'yyyy', locale='en')
         if not self.day:
-            return dates.format_date(datetime.date(self.year, self.month, 1), 'MMM, YYYY', locale='en')
-        return dates.format_date(datetime.date(self.year, self.month, self.day), 'MMM d, YYYY', locale='en')
+            return dates.format_date(datetime.date(self.year, self.month, 1), 'MMM, yyyy', locale='en')
+        return dates.format_date(datetime.date(self.year, self.month, self.day), 'MMM d, yyyy', locale='en')
 
 
 def normalize_date(date, **kwargs):
@@ -241,7 +241,7 @@ def format_date(date):
     return PartialDate.loads(date).pprint()
 
 
-def earliest_date(dates, full_date=False):
+def earliest_date(dates):
     """Return the earliest among the schema-compliant dates.
 
     This is a convenience wrapper around :ref:`PartialDate`, which should be
@@ -249,13 +249,22 @@ def earliest_date(dates, full_date=False):
 
     Args:
         dates(list): List of dates from which oldest/earliest one will be returned
-        full_date(bool): Adds month and/or day as "01" if they are missing
     Returns:
         str: Earliest date from provided list
     """
     min_date = min(PartialDate.loads(date) for date in dates)
-    if not min_date.month and full_date:
-        min_date.month = 1
-    if not min_date.day and full_date:
-        min_date.day = 1
     return min_date.dumps()
+
+
+def fill_missing_date_parts(date):
+    """Sets missing day and/or month to 1. Useful to avoid errors when saving to DB."""
+
+    if date is None:
+        return
+
+    date_obj = PartialDate.loads(date)
+    if not date_obj.month:
+        date_obj.month = 1
+    if not date_obj.day:
+        date_obj.day = 1
+    return date_obj.dumps()

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -29,6 +29,7 @@ from inspire_utils.date import (
     earliest_date,
     format_date,
     normalize_date,
+    fill_missing_date_parts
 )
 
 
@@ -85,6 +86,16 @@ def test_partial_date_pprints_when_cast_to_str():
     expected = 'Jun, 1686'
 
     assert expected == str(PartialDate(1686, 6))
+
+
+def test_partial_date_pprints_correct_date():
+    expected_full = 'Jan 1, 1890'
+    expected_no_day = 'Jan, 1890'
+    expected_no_month = '1890'
+
+    assert expected_full == PartialDate(1890, 1, 1).pprint()
+    assert expected_no_day == PartialDate(1890, 1).pprint()
+    assert expected_no_month == PartialDate(1890).pprint()
 
 
 def test_format_date():
@@ -159,16 +170,22 @@ def test_earliest_date():
     assert expected == result
 
 
-def test_earliest_date_missing_month_and_day_with_full_date():
-    assert earliest_date(["2000"], full_date=True) == "2000-01-01"
-
-
-def test_earliest_date_missing_month_and_day_without_full_date():
-    assert earliest_date(["2000"]) == "2000"
-
-
 def test_format_date_only_year_regression_iso_week_misuse():
     expected = u'1993'
     result = format_date('1993')
+
+    assert expected == result
+
+
+def test_fill_missing_date_parts_adds_day():
+    expected = "2019-06-01"
+    result = fill_missing_date_parts("2019-06")
+
+    assert expected == result
+
+
+def test_fill_missing_date_parts_adds_month_and_day():
+    expected = "2019-01-01"
+    result = fill_missing_date_parts("2019")
 
     assert expected == result


### PR DESCRIPTION
Now it uses the actual year instead of the year by week

* INSPIR-3165