### PR TITLE
setup: downgrade lxml to match inspirehep requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup_requires = [
 install_requires = [
     'Unidecode~=1.0,>=1.0.22',
     'babel~=2.0,>=2.5.1',
-    'lxml~=4.0,>=4.4.0',
+    'lxml~=4.0,>=4.3.0',
     'nameparser~=0.0,>=0.5.3',
     'python-dateutil~=2.0,>=2.6.1',
     'six~=1.0,>=1.10.0',


### PR DESCRIPTION
* INSPIR-3477
* lxml version higher than 4.3 breaks orcid tests