### PR TITLE
ParsedName: add method to generate es name query

### DIFF
--- a/inspire_utils/query.py
+++ b/inspire_utils/query.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INSPIRE.
+# Copyright (C) 2014-2017 CERN.
+#
+# INSPIRE is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# INSPIRE is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with INSPIRE. If not, see <http://www.gnu.org/licenses/>.
+#
+# In applying this license, CERN does not waive the privileges and immunities
+# granted to it by virtue of its status as an Intergovernmental Organization
+# or submit itself to any jurisdiction.
+from __future__ import absolute_import, division, print_function
+
+
+def wrap_queries_in_bool_clauses_if_more_than_one(
+    queries, use_must_clause, preserve_bool_semantics_if_one_clause=False
+):
+    """Helper for wrapping a list of queries into a bool.{must, should} clause.
+    Args:
+        queries (list): List of queries to be wrapped in a bool.{must, should} clause.
+        use_must_clause (bool): Flag that signifies whether to use 'must' or 'should' clause.
+        preserve_bool_semantics_if_one_clause (bool): Flag that signifies whether to generate a bool query even if
+            there's only one clause. This happens to generate boolean query semantics. Usually not the case, but
+            useful for boolean queries support.
+    Returns:
+        (dict): If len(queries) > 1, the bool clause, otherwise if len(queries) == 1, will return the query itself,
+                while finally, if len(queries) == 0, then an empty dictionary is returned.
+    """
+    if not queries:
+        return {}
+
+    queries = [q for q in queries if q]
+
+    if len(queries) == 1 and not preserve_bool_semantics_if_one_clause:
+        return queries[0]
+
+    return {"bool": {"must" if use_must_clause else "should": queries}}
+
+
+def ordered(obj):
+    """
+    Helper to order the dictionary
+    """
+    # See https://stackoverflow.com/a/25851972
+    if isinstance(obj, dict):
+        return sorted((k, ordered(v)) for k, v in obj.items())
+    if isinstance(obj, list):
+        return sorted(ordered(x) for x in obj)
+    else:
+        return obj

--- a/tests/test_name.py
+++ b/tests/test_name.py
@@ -23,136 +23,135 @@
 from __future__ import absolute_import, division, print_function
 
 import pytest
+from inspire_utils.name import (ParsedName, format_name,
+                                generate_name_variations, normalize_name)
+from inspire_utils.query import ordered
 from mock import patch
-
-from inspire_utils.name import (
-    normalize_name,
-    format_name,
-    generate_name_variations,
-    ParsedName,
-)
 
 
 def test_normalize_name_full():
-    expected = 'Smith, John Peter'
+    expected = "Smith, John Peter"
 
-    assert expected == normalize_name('Smith, John Peter')
+    assert expected == normalize_name("Smith, John Peter")
 
 
 def test_normalize_name_handles_names_with_first_initial():
-    expected = 'Smith, J. Peter'
+    expected = "Smith, J. Peter"
 
-    assert expected == normalize_name('Smith, J Peter')
-    assert expected == normalize_name('Smith, J. Peter')
-    assert expected == normalize_name('Smith, J. Peter ')
+    assert expected == normalize_name("Smith, J Peter")
+    assert expected == normalize_name("Smith, J. Peter")
+    assert expected == normalize_name("Smith, J. Peter ")
 
 
 def test_normalize_name_handles_names_with_middle_initial():
-    expected = 'Smith, John P.'
+    expected = "Smith, John P."
 
-    assert expected == normalize_name('Smith, John P.')
-    assert expected == normalize_name('Smith, John P. ')
-    assert expected == normalize_name('Smith, John P ')
+    assert expected == normalize_name("Smith, John P.")
+    assert expected == normalize_name("Smith, John P. ")
+    assert expected == normalize_name("Smith, John P ")
 
 
 def test_normalize_name_handles_names_with_dots_initials():
-    expected = 'Smith, J.P.'
+    expected = "Smith, J.P."
 
-    assert expected == normalize_name('Smith, J. P.')
-    assert expected == normalize_name('Smith, J.P.')
-    assert expected == normalize_name('Smith, J.P. ')
-    assert expected == normalize_name('Smith, J. P. ')
+    assert expected == normalize_name("Smith, J. P.")
+    assert expected == normalize_name("Smith, J.P.")
+    assert expected == normalize_name("Smith, J.P. ")
+    assert expected == normalize_name("Smith, J. P. ")
 
 
 def test_normalize_name_handles_names_with_spaces():
-    expected = 'Smith, J.P.'
+    expected = "Smith, J.P."
 
-    assert expected == normalize_name('Smith, J P ')
-    assert expected == normalize_name('Smith, J P')
+    assert expected == normalize_name("Smith, J P ")
+    assert expected == normalize_name("Smith, J P")
 
 
 def test_normalize_name_handles_names_with_several_last_names():
-    expected = 'Smith Davis, J.P.'
+    expected = "Smith Davis, J.P."
 
-    assert expected == normalize_name('Smith Davis, J.P.')
+    assert expected == normalize_name("Smith Davis, J.P.")
 
 
 def test_normalize_name_handles_jimmy():  # http://jimmy.pink
-    expected = 'Jimmy'
+    expected = "Jimmy"
 
-    assert expected == normalize_name('Jimmy')
+    assert expected == normalize_name("Jimmy")
 
 
 def test_normalize_name_handles_unicode():
-    expected = u'蕾拉'
+    expected = u"蕾拉"
 
-    assert expected == normalize_name(u'蕾拉')
+    assert expected == normalize_name(u"蕾拉")
 
 
 def test_normalize_name_converts_unicode_apostrophe_to_normal_apostrophe():
-    expected = u'M\'Gregor, Jimmy'
+    expected = u"M'Gregor, Jimmy"
 
-    assert expected == normalize_name(u'M’Gregor, Jimmy')
+    assert expected == normalize_name(u"M’Gregor, Jimmy")
 
 
-@pytest.mark.parametrize("input_author_name,expected", [
-    ('Smith, John Jr', 'Smith, John, Jr.'),
-    ('Smith, John Jr.', 'Smith, John, Jr.'),
-    ('Smith, John III', 'Smith, John, III'),
-    ('Smith, John iii', 'Smith, John, III'),
-    ('Smith, John VIII', 'Smith, John, VIII'),
-    ('Smith, John viii', 'Smith, John, VIII'),
-    ('Smith, John IV', 'Smith, John, IV'),
-    ('Smith, John iv', 'Smith, John, IV'),
-])
+@pytest.mark.parametrize(
+    "input_author_name,expected",
+    [
+        ("Smith, John Jr", "Smith, John, Jr."),
+        ("Smith, John Jr.", "Smith, John, Jr."),
+        ("Smith, John III", "Smith, John, III"),
+        ("Smith, John iii", "Smith, John, III"),
+        ("Smith, John VIII", "Smith, John, VIII"),
+        ("Smith, John viii", "Smith, John, VIII"),
+        ("Smith, John IV", "Smith, John, IV"),
+        ("Smith, John iv", "Smith, John, IV"),
+    ],
+)
 def test_normalize_name_handles_suffixes(input_author_name, expected):
     assert normalize_name(input_author_name) == expected
 
 
-@pytest.mark.parametrize("input_author_name,expected", [
-    ('Sir John Smith', 'Smith, John'),
-    ('Bao, Hon', 'Bao, Hon'),
-])
+@pytest.mark.parametrize(
+    "input_author_name,expected",
+    [("Sir John Smith", "Smith, John"), ("Bao, Hon", "Bao, Hon")],
+)
 def test_normalize_name_handles_titles(input_author_name, expected):
     assert normalize_name(input_author_name) == expected
 
 
 def test_generate_name_variations_with_two_non_lastnames():
-    name = 'Ellis, John Richard'
+    name = "Ellis, John Richard"
     expected_name_variations = {
-        'ellis',
-        'ellis j',
-        'ellis j r',
-        'ellis j richard',
-        'ellis john',
-        'ellis john r',
-        'ellis john richard',
-        'ellis r',
-        'ellis richard',
-        'ellis, j',
-        'ellis, j r',
-        'ellis, j richard',
-        'ellis, john',
-        'ellis, john r',
-        'ellis, john richard',
-        'ellis, r',
-        'ellis, richard',
-        'j ellis',
-        'j r ellis',
-        'j richard ellis',
-        'john ellis',
-        'john r ellis',
-        'john richard ellis',
-        'r ellis',
-        'richard ellis',
-        'j, ellis',
-        'j r, ellis',
-        'j richard, ellis',
-        'john, ellis',
-        'john r, ellis',
-        'john richard, ellis',
-        'r, ellis',
-        'richard, ellis',
+        "ellis",
+        "ellis j",
+        "ellis j r",
+        "ellis j richard",
+        "ellis john",
+        "ellis john r",
+        "ellis john richard",
+        "ellis r",
+        "ellis richard",
+        "ellis, j",
+        "ellis, j r",
+        "ellis, j richard",
+        "ellis, john",
+        "ellis, john r",
+        "ellis, john richard",
+        "ellis, r",
+        "ellis, richard",
+        "j ellis",
+        "j r ellis",
+        "j richard ellis",
+        "john ellis",
+        "john r ellis",
+        "john richard ellis",
+        "r ellis",
+        "richard ellis",
+        "j, ellis",
+        "j r, ellis",
+        "j richard, ellis",
+        "john, ellis",
+        "john r, ellis",
+        "john richard, ellis",
+        "r, ellis",
+        "richard, ellis",
     }
 
     result = generate_name_variations(name)
@@ -161,46 +160,46 @@ def test_generate_name_variations_with_two_non_lastnames():
 
 
 def test_generate_name_variations_with_more_than_two_non_lastnames_does_not_add_extra_spaces():
-    name = 'Ellis, John Richard Philip'
+    name = "Ellis, John Richard Philip"
 
     result = generate_name_variations(name)
 
-    assert 'ellis, john  philip' not in set(result)
+    assert "ellis, john  philip" not in set(result)
 
 
 def test_generate_name_variations_with_two_lastnames():
-    name = u'Caro Estevez, David'
+    name = u"Caro Estevez, David"
     expected = {
         # Lastnames only
-        u'caro',
-        u'estevez',
-        u'caro estevez',
+        u"caro",
+        u"estevez",
+        u"caro estevez",
         # Lastnames first and then non lastnames
-        u'caro estevez d',
-        u'caro estevez david',
-        u'caro estevez, d',
-        u'caro estevez, david',
-        u'caro d',
-        u'caro, d',
-        u'caro david',
-        u'caro, david',
-        u'estevez d',
-        u'estevez david',
-        u'estevez, d',
-        u'estevez, david',
+        u"caro estevez d",
+        u"caro estevez david",
+        u"caro estevez, d",
+        u"caro estevez, david",
+        u"caro d",
+        u"caro, d",
+        u"caro david",
+        u"caro, david",
+        u"estevez d",
+        u"estevez david",
+        u"estevez, d",
+        u"estevez, david",
         # Non lastnames first and then lastnames
-        u'd caro',
-        u'd, caro',
-        u'd estevez',
-        u'd, estevez',
-        u'd caro estevez',
-        u'd, caro estevez',
-        u'david caro',
-        u'david, caro',
-        u'david estevez',
-        u'david, estevez',
-        u'david caro estevez',
-        u'david, caro estevez',
+        u"d caro",
+        u"d, caro",
+        u"d estevez",
+        u"d, estevez",
+        u"d caro estevez",
+        u"d, caro estevez",
+        u"david caro",
+        u"david, caro",
+        u"david estevez",
+        u"david, estevez",
+        u"david caro estevez",
+        u"david, caro estevez",
     }
 
     result = generate_name_variations(name)
@@ -209,47 +208,47 @@ def test_generate_name_variations_with_two_lastnames():
 
 
 def test_generate_name_variations_with_three_lastnames_dashed_ignores_the_dash():
-    name = u'Caro-Estévez Martínez, David'
+    name = u"Caro-Estévez Martínez, David"
     expected = {
         # Lastnames only
-        u'caro',
-        u'estevez',
-        u'martinez',
-        u'caro estevez martinez',
+        u"caro",
+        u"estevez",
+        u"martinez",
+        u"caro estevez martinez",
         # Lastnames first and then non lastnames
-        u'caro estevez martinez d',
-        u'caro estevez martinez david',
-        u'caro estevez martinez, d',
-        u'caro estevez martinez, david',
-        u'caro d',
-        u'caro, d',
-        u'caro david',
-        u'caro, david',
-        u'estevez d',
-        u'estevez, d',
-        u'estevez david',
-        u'estevez, david',
-        u'martinez d',
-        u'martinez, d',
-        u'martinez david',
-        u'martinez, david',
+        u"caro estevez martinez d",
+        u"caro estevez martinez david",
+        u"caro estevez martinez, d",
+        u"caro estevez martinez, david",
+        u"caro d",
+        u"caro, d",
+        u"caro david",
+        u"caro, david",
+        u"estevez d",
+        u"estevez, d",
+        u"estevez david",
+        u"estevez, david",
+        u"martinez d",
+        u"martinez, d",
+        u"martinez david",
+        u"martinez, david",
         # Non lastnames first and then lastnames
-        u'd caro',
-        u'd, caro',
-        u'd estevez',
-        u'd, estevez',
-        u'd martinez',
-        u'd, martinez',
-        u'd caro estevez martinez',
-        u'd, caro estevez martinez',
-        u'david caro',
-        u'david, caro',
-        u'david estevez',
-        u'david, estevez',
-        u'david martinez',
-        u'david, martinez',
-        u'david caro estevez martinez',
-        u'david, caro estevez martinez'
+        u"d caro",
+        u"d, caro",
+        u"d estevez",
+        u"d, estevez",
+        u"d martinez",
+        u"d, martinez",
+        u"d caro estevez martinez",
+        u"d, caro estevez martinez",
+        u"david caro",
+        u"david, caro",
+        u"david estevez",
+        u"david, estevez",
+        u"david martinez",
+        u"david, martinez",
+        u"david caro estevez martinez",
+        u"david, caro estevez martinez",
     }
 
     result = generate_name_variations(name)
@@ -258,16 +257,16 @@ def test_generate_name_variations_with_three_lastnames_dashed_ignores_the_dash()
 
 
 def test_generate_name_variations_with_firstname_as_initial():
-    name = 'Smith, J'
+    name = "Smith, J"
     expected = {
         # Lastname only
-        u'smith',
+        u"smith",
         # Lastnames first and then non lastnames
-        u'smith j',
-        u'smith, j',
+        u"smith j",
+        u"smith, j",
         # Non lastnames first and then lastnames
-        u'j smith',
-        u'j, smith',
+        u"j smith",
+        u"j, smith",
     }
 
     result = generate_name_variations(name)
@@ -276,9 +275,9 @@ def test_generate_name_variations_with_firstname_as_initial():
 
 
 def test_generate_name_variations_with_only_one_name():
-    name = 'Jimmy'
+    name = "Jimmy"
     expected = {
-        u'jimmy',
+        u"jimmy",
     }
 
     result = generate_name_variations(name)
@@ -288,9 +287,10 @@ def test_generate_name_variations_with_only_one_name():
 
 def test_generate_name_variations_with_many_names_defers_generating_variations():
     import logging
-    logger = logging.getLogger('inspire_utils.name')
-    with patch.object(logger, 'warning') as mock_warning:
-        many_names_as_one_author = 'Tseng, Farrukh Azfar Todd Huffman Thilo Pauly'
+
+    logger = logging.getLogger("inspire_utils.name")
+    with patch.object(logger, "warning") as mock_warning:
+        many_names_as_one_author = "Tseng, Farrukh Azfar Todd Huffman Thilo Pauly"
 
         result = generate_name_variations(many_names_as_one_author)
 
@@ -298,24 +298,25 @@ def test_generate_name_variations_with_many_names_defers_generating_variations()
 
         args, _ = mock_warning.call_args
         assert args[0].startswith(
-            'Skipping name variations generation - too many names')
+            "Skipping name variations generation - too many names"
+        )
 
 
 def test_generate_name_variations_capitalizes_first_letters():
-    name = 'mele, salvatore'
+    name = "mele, salvatore"
     expected = {
         # Lastname only
-        u'mele',
+        u"mele",
         # Lastnames first and then non lastnames
-        u'mele s',
-        u'mele, s',
-        u'mele salvatore',
-        u'mele, salvatore',
+        u"mele s",
+        u"mele, s",
+        u"mele salvatore",
+        u"mele, salvatore",
         # Non lastnames first and then lastnames
-        u'salvatore mele',
-        u'salvatore, mele',
-        u's mele',
-        u's, mele',
+        u"salvatore mele",
+        u"salvatore, mele",
+        u"s mele",
+        u"s, mele",
     }
 
     result = generate_name_variations(name)
@@ -324,20 +325,20 @@ def test_generate_name_variations_capitalizes_first_letters():
 
 
 def test_generate_name_variations_works_with_two_consecutive_commas():
-    name = 'Perelstein,, Maxim'
+    name = "Perelstein,, Maxim"
     expected = {
         # Lastname only
-        u'perelstein',
+        u"perelstein",
         # Lastnames first and then non lastnames
-        u'perelstein m',
-        u'perelstein, m',
-        u'perelstein maxim',
-        u'perelstein, maxim',
+        u"perelstein m",
+        u"perelstein, m",
+        u"perelstein maxim",
+        u"perelstein, maxim",
         # Non lastnames first and then lastnames
-        u'maxim perelstein',
-        u'maxim, perelstein',
-        u'm perelstein',
-        u'm, perelstein',
+        u"maxim perelstein",
+        u"maxim, perelstein",
+        u"m perelstein",
+        u"m, perelstein",
     }
 
     result = generate_name_variations(name)
@@ -347,16 +348,16 @@ def test_generate_name_variations_works_with_two_consecutive_commas():
 
 def test_generate_name_variations_with_short_lastname_and_initial():
     # Should not output something like `o y` or any similar variation.
-    name = 'Oz, Y'
+    name = "Oz, Y"
     expected = {
         # Lastname only
-        u'oz',
+        u"oz",
         # Lastnames first and then non lastnames
-        u'oz y',
-        u'oz, y',
+        u"oz y",
+        u"oz, y",
         # Non lastnames first and then lastnames
-        u'y oz',
-        u'y, oz',
+        u"y oz",
+        u"y, oz",
     }
 
     result = generate_name_variations(name)
@@ -376,41 +377,41 @@ def test_parsed_name_from_parts():
 
 
 def test_normalize_name_handles_multiple_middle_names():
-    expected = 'Almeida, C.A.S.'
+    expected = "Almeida, C.A.S."
 
-    assert expected == normalize_name('Almeida, C. A. S.')
-    assert expected == normalize_name('Almeida, C. A.S.')
-    assert expected == normalize_name('Almeida, C.A. S.')
-    assert expected == normalize_name('Almeida, C.A.S.')
+    assert expected == normalize_name("Almeida, C. A. S.")
+    assert expected == normalize_name("Almeida, C. A.S.")
+    assert expected == normalize_name("Almeida, C.A. S.")
+    assert expected == normalize_name("Almeida, C.A.S.")
 
 
 def test_normalize_name_handles_multiple_middle_names_with_and_without_initials():
-    expected = 'Smith, J.A. Peter J.'
+    expected = "Smith, J.A. Peter J."
 
-    assert expected == normalize_name('Smith, J. A. Peter J.')
-    assert expected == normalize_name('Smith, J.A. Peter J.')
+    assert expected == normalize_name("Smith, J. A. Peter J.")
+    assert expected == normalize_name("Smith, J.A. Peter J.")
 
 
 def test_format_author_name():
-    expected = 'Stanley Martin Lieber'
+    expected = "Stanley Martin Lieber"
 
-    assert expected == format_name('Lieber, Stanley Martin')
+    assert expected == format_name("Lieber, Stanley Martin")
 
-    expected = 'Robert Downey, Jr.'
+    expected = "Robert Downey, Jr."
 
-    assert expected == format_name('Downey, Robert Jr.')
+    assert expected == format_name("Downey, Robert Jr.")
 
 
 def test_format_author_name_with_initials():
-    expected = 'S. M. Lieber'
+    expected = "S. M. Lieber"
 
-    assert expected == format_name('Lieber, Stanley Martin', initials_only=True)
+    assert expected == format_name("Lieber, Stanley Martin", initials_only=True)
 
 
 def test_format_author_name_with_initials_with_all_caps_name():
-    expected = 'T. S. Holland'
+    expected = "T. S. Holland"
 
-    assert expected == format_name('HOLLAND, TOM STANLEY', initials_only=True)
+    assert expected == format_name("HOLLAND, TOM STANLEY", initials_only=True)
 
 
 def test_parsed_name_initials():
@@ -419,18 +420,15 @@ def test_parsed_name_initials():
 
     assert expected == parsed_name.first_initials
 
-    expected = [
-        "T.",
-        "S."
-    ]
+    expected = ["T.", "S."]
 
     assert expected == parsed_name.first_initials_list
 
 
 def test_parsed_wrong_names_and_not_fail():
     names = [
-        (u'Proffesor.M.', u'Proffesor.M.'),
-        (u'ˇ Sirˇ', u'Sirˇ, ˇ.'),
+        (u"Proffesor.M.", u"Proffesor.M."),
+        (u"ˇ Sirˇ", u"Sirˇ, ˇ."),
     ]
 
     for name, expected in names:
@@ -438,20 +436,20 @@ def test_parsed_wrong_names_and_not_fail():
 
 
 def test_unicode_characters_in_format_name():
-    assert format_name('Cañas, Ramón') == u'Ramón Cañas'
-    assert format_name('Süß, Jörg') == u'Jörg Süß'
-    assert format_name('Møller, Kyösti') == u'Kyösti Møller'
-    assert format_name('Varejão, François') == u'François Varejão'
+    assert format_name("Cañas, Ramón") == u"Ramón Cañas"
+    assert format_name("Süß, Jörg") == u"Jörg Süß"
+    assert format_name("Møller, Kyösti") == u"Kyösti Møller"
+    assert format_name("Varejão, François") == u"François Varejão"
 
 
 def test_first_names_are_never_printed_with_initials_only_if_no_last_name():
-    expected = u'Jimmy'
+    expected = u"Jimmy"
 
-    assert expected == format_name('Jimmy', initials_only=True)
+    assert expected == format_name("Jimmy", initials_only=True)
 
 
 def test_first_name_with_dash_is_initialized_correctly():
-    assert u'Z. Y. Yin' == format_name('Zhao-Yu Yin', initials_only=True)
+    assert u"Z. Y. Yin" == format_name("Zhao-Yu Yin", initials_only=True)
 
 
 def test_first_name_with_dash_is_printed_with_dash_and_initialized_correctly():
@@ -462,8 +460,860 @@ def test_first_name_with_dash_is_printed_with_dash_and_initialized_correctly():
 
 
 def test_first_name_initials_without_whitespace_is_initialized_correctly():
-    assert u'M. A. M. G. Garcia' == format_name('Miguel A-M.G. Garcia', initials_only=True)
+    assert u"M. A. M. G. Garcia" == format_name(
+        "Miguel A-M.G. Garcia", initials_only=True
+    )
 
 
 def test_last_name_recognized_correctly_regression_test():
-    assert u"De Sousa Vieira" == ParsedName.loads('De Sousa Vieira, M.C.').last
+    assert u"De Sousa Vieira" == ParsedName.loads("De Sousa Vieira, M.C.").last
+
+
+def test_generate_es_query_lastname_firstname_with_commas_and_initials():
+    name = "ellis, john k."
+
+    expected_query = {
+        "nested": {
+            "path": "authors",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "authors.last_name": {
+                                    "operator": "AND",
+                                    "query": "Ellis",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "bool": {
+                                            "should": [
+                                                {
+                                                    "match_phrase_prefix": {
+                                                        "authors.first_name": {
+                                                            "analyzer": "names_analyzer",
+                                                            "query": "John",
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "match": {
+                                                        "authors.first_name": {
+                                                            "analyzer": "names_initials_analyzer",
+                                                            "operator": "AND",
+                                                            "query": "John",
+                                                        }
+                                                    }
+                                                },
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "authors.first_name.initials": {
+                                                "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
+                                                "query": "K",
+                                            }
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query()
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_first_author_lastname_firstname_with_commas_and_initials():
+    name = "ellis, john k."
+
+    expected_query = {
+        "nested": {
+            "path": "first_author",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "first_author.last_name": {
+                                    "operator": "AND",
+                                    "query": "Ellis",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "bool": {
+                                            "should": [
+                                                {
+                                                    "match_phrase_prefix": {
+                                                        "first_author.first_name": {
+                                                            "analyzer": "names_analyzer",
+                                                            "query": "John",
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "match": {
+                                                        "first_author.first_name": {
+                                                            "analyzer": "names_initials_analyzer",
+                                                            "operator": "AND",
+                                                            "query": "John",
+                                                        }
+                                                    }
+                                                },
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "first_author.first_name.initials": {
+                                                "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
+                                                "query": "K",
+                                            }
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query("first_author")
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_query_author_with_composite_last_name():
+    name = "de Rham"
+    expected_query = {
+        "nested": {
+            "path": "authors",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "authors.last_name": {
+                                    "query": "Rham",
+                                    "operator": "AND",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "match_phrase_prefix": {
+                                            "authors.first_name": {
+                                                "query": "de",
+                                                "analyzer": "names_analyzer",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "authors.first_name": {
+                                                "query": "de",
+                                                "operator": "AND",
+                                                "analyzer": "names_initials_analyzer",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "authors.full_name": {
+                                                "query": "de Rham",
+                                                "operator": "AND",
+                                            }
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query()
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_split_fa_initial_and_firstname_without_a_space():
+    name = "D.John Smith"
+    expected_query = {
+        "nested": {
+            "path": "first_author",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "first_author.last_name": {
+                                    "operator": "AND",
+                                    "query": "Smith",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "match": {
+                                            "first_author.first_name.initials": {
+                                                "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
+                                                "query": "D",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "bool": {
+                                            "should": [
+                                                {
+                                                    "match_phrase_prefix": {
+                                                        "first_author.first_name": {
+                                                            "analyzer": "names_analyzer",
+                                                            "query": "John",
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "match": {
+                                                        "first_author.first_name": {
+                                                            "analyzer": "names_initials_analyzer",
+                                                            "operator": "AND",
+                                                            "query": "John",
+                                                        }
+                                                    }
+                                                },
+                                            ]
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query("first_author")
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_hack_to_split_two_initials_without_a_space():
+    name = "D.K. Smith"
+    expected_query = {
+        "nested": {
+            "path": "authors",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "authors.last_name": {
+                                    "operator": "AND",
+                                    "query": "Smith",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "match": {
+                                            "authors.first_name.initials": {
+                                                "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
+                                                "query": "D",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "authors.first_name.initials": {
+                                                "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
+                                                "query": "K",
+                                            }
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query("authors")
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_split_fa_two_initials_without_a_space():
+    name = "D.K. Smith"
+    expected_query = {
+        "nested": {
+            "path": "first_author",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "first_author.last_name": {
+                                    "operator": "AND",
+                                    "query": "Smith",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "match": {
+                                            "first_author.first_name.initials": {
+                                                "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
+                                                "query": "D",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "first_author.first_name.initials": {
+                                                "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
+                                                "query": "K",
+                                            }
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query("first_author")
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_lastname_initial():
+    name = "ellis, j"
+    expected_query = {
+        "nested": {
+            "path": "authors",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "authors.last_name": {
+                                    "operator": "AND",
+                                    "query": "Ellis",
+                                }
+                            }
+                        },
+                        {
+                            "match": {
+                                "authors.first_name.initials": {
+                                    "analyzer": "names_initials_analyzer",
+                                    "operator": "AND",
+                                    "query": "J",
+                                }
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query()
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_first_author_lastname_initial():
+    name = "ellis, j"
+    expected_query = {
+        "nested": {
+            "path": "first_author",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "first_author.last_name": {
+                                    "operator": "AND",
+                                    "query": "Ellis",
+                                }
+                            }
+                        },
+                        {
+                            "match": {
+                                "first_author.first_name.initials": {
+                                    "analyzer": "names_initials_analyzer",
+                                    "operator": "AND",
+                                    "query": "J",
+                                }
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query("first_author")
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_lastname_firstname():
+    name = "ellis, john"
+
+    expected_query = {
+        "nested": {
+            "path": "authors",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "authors.last_name": {
+                                    "operator": "AND",
+                                    "query": "Ellis",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "match_phrase_prefix": {
+                                            "authors.first_name": {
+                                                "analyzer": "names_analyzer",
+                                                "query": "John",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "authors.first_name": {
+                                                "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
+                                                "query": "John",
+                                            }
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query()
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_first_author_lastname_firstname():
+    name = "ellis, john"
+
+    expected_query = {
+        "nested": {
+            "path": "first_author",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "first_author.last_name": {
+                                    "operator": "AND",
+                                    "query": "Ellis",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "match_phrase_prefix": {
+                                            "first_author.first_name": {
+                                                "analyzer": "names_analyzer",
+                                                "query": "John",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "first_author.first_name": {
+                                                "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
+                                                "query": "John",
+                                            }
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query("first_author")
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_lastname_firstname_without_comma():
+    name = "john ellis"
+
+    expected_query = {
+        "nested": {
+            "path": "authors",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "authors.last_name": {
+                                    "query": "Ellis",
+                                    "operator": "AND",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "match_phrase_prefix": {
+                                            "authors.first_name": {
+                                                "query": "John",
+                                                "analyzer": "names_analyzer",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "authors.first_name": {
+                                                "query": "John",
+                                                "operator": "AND",
+                                                "analyzer": "names_initials_analyzer",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "authors.full_name": {
+                                                "query": "John Ellis",
+                                                "operator": "AND",
+                                            }
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query()
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_first_author_lastname_firstname_without_comma():
+    name = "john ellis"
+
+    expected_query = {
+        "nested": {
+            "path": "first_author",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "first_author.last_name": {
+                                    "query": "Ellis",
+                                    "operator": "AND",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "match_phrase_prefix": {
+                                            "first_author.first_name": {
+                                                "query": "John",
+                                                "analyzer": "names_analyzer",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "first_author.first_name": {
+                                                "query": "John",
+                                                "operator": "AND",
+                                                "analyzer": "names_initials_analyzer",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "first_author.full_name": {
+                                                "query": "John Ellis",
+                                                "operator": "AND",
+                                            }
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query("first_author")
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_lastname_firstname_without_commas_and_initials():
+    name = "john k. ellis"
+
+    expected_query = {
+        "nested": {
+            "path": "authors",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "authors.last_name": {
+                                    "operator": "AND",
+                                    "query": "Ellis",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "bool": {
+                                            "should": [
+                                                {
+                                                    "match_phrase_prefix": {
+                                                        "authors.first_name": {
+                                                            "analyzer": "names_analyzer",
+                                                            "query": "John",
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "match": {
+                                                        "authors.first_name": {
+                                                            "analyzer": "names_initials_analyzer",
+                                                            "operator": "AND",
+                                                            "query": "John",
+                                                        }
+                                                    }
+                                                },
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "authors.first_name.initials": {
+                                                "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
+                                                "query": "K",
+                                            }
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query()
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_first_author_lastname_firstname_without_commas_and_initials():
+    name = "john k. ellis"
+
+    expected_query = {
+        "nested": {
+            "path": "first_author",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "first_author.last_name": {
+                                    "operator": "AND",
+                                    "query": "Ellis",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "bool": {
+                                            "should": [
+                                                {
+                                                    "match_phrase_prefix": {
+                                                        "first_author.first_name": {
+                                                            "analyzer": "names_analyzer",
+                                                            "query": "John",
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "match": {
+                                                        "first_author.first_name": {
+                                                            "analyzer": "names_initials_analyzer",
+                                                            "operator": "AND",
+                                                            "query": "John",
+                                                        }
+                                                    }
+                                                },
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "first_author.first_name.initials": {
+                                                "analyzer": "names_initials_analyzer",
+                                                "operator": "AND",
+                                                "query": "K",
+                                            }
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query("first_author")
+    assert ordered(generated_es_query) == ordered(expected_query)
+
+
+def test_generate_es_query_works_for_unambigous_names():
+    name = "J. David Ellis"
+
+    expected_query = {
+        "nested": {
+            "path": "authors",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "authors.last_name": {
+                                    "query": "Ellis",
+                                    "operator": "AND",
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "match": {
+                                            "authors.first_name.initials": {
+                                                "query": "J",
+                                                "operator": "AND",
+                                                "analyzer": "names_initials_analyzer",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "bool": {
+                                            "should": [
+                                                {
+                                                    "match_phrase_prefix": {
+                                                        "authors.first_name": {
+                                                            "query": "David",
+                                                            "analyzer": "names_analyzer",
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "match": {
+                                                        "authors.first_name": {
+                                                            "query": "David",
+                                                            "operator": "AND",
+                                                            "analyzer": "names_initials_analyzer",
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "match": {
+                                                        "authors.full_name": {
+                                                            "query": "J. David Ellis",
+                                                            "operator": "AND",
+                                                        }
+                                                    }
+                                                },
+                                            ]
+                                        }
+                                    },
+                                ]
+                            }
+                        },
+                    ]
+                }
+            },
+        }
+    }
+
+    parsed_name = ParsedName(name)
+    generated_es_query = parsed_name.generate_es_query()
+    assert ordered(generated_es_query) == ordered(expected_query)


### PR DESCRIPTION
* move the functionality from inspire-query-parsed so that it can be reused in other modules